### PR TITLE
Halyard now uses puppet-run not halyard

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,8 +29,8 @@ class halyard (
   }
 
   $commands = [
-    "${repo_path}/meta/halyard",
-    "/bin/sh -c ${repo_path}/meta/halyard"
+    "${repo_path}/meta/puppet-run",
+    "/bin/sh -c ${repo_path}/meta/puppet-run"
   ]
 
   sudoers::allowed_command{ 'halyard_puppet':


### PR DESCRIPTION
```
❯ halyard
Password:
Repo is unclean: /opt/halyard/repo
2018-05-15 19:07:11 Jareds-MacBook-Pro.local STARTING RUN
2018-05-15 19:07:18 Jareds-MacBook-Pro.local Notice: Compiled catalog for jareds-macbook-pro.local in environment production in 0.66 seconds
2018-05-15 19:07:19 Jareds-MacBook-Pro.local Notice: /Stage[main]/Halyard/Sudoers::Allowed_command[halyard_puppet]/File[/etc/sudoers.d/halyard_puppet]/content: content changed '{md5}8fd6def48b20bcf4bd829ac382b6dc46' to '{md5}70dcf5a8931b3afd930c61f75c4a83c7'
2018-05-15 19:07:22 Jareds-MacBook-Pro.local Notice: Applied catalog in 3.66 seconds
2018-05-15 19:07:22 Jareds-MacBook-Pro.local ENDING RUN
```
followed by
```
/opt/halyard/repo master*
❯ sudo -k

/opt/halyard/repo master*
❯ halyard
Repo is unclean: /opt/halyard/repo
2018-05-15 19:08:39 Jareds-MacBook-Pro.local STARTING RUN
2018-05-15 19:08:46 Jareds-MacBook-Pro.local Notice: Compiled catalog for jareds-macbook-pro.local in environment production in 0.54 seconds
2018-05-15 19:08:49 Jareds-MacBook-Pro.local Notice: Applied catalog in 2.81 seconds
2018-05-15 19:08:49 Jareds-MacBook-Pro.local ENDING RUN
```