### PR TITLE
Allow for customized sudo env vaiables

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@
 #
 
 class halyard (
+  Array[String] $allowed_env_variables = ['DEBUG', 'PUPPET_ENV', 'PROFILE']
 ) {
   $root_path = '/opt/halyard'
   $repo_path = "${root_path}/repo"
@@ -39,7 +40,7 @@ class halyard (
     require_password      => false,
     comment               => 'Allows halyard user to run puppet',
     require_exist         => false,
-    allowed_env_variables => ['DEBUG', 'PUPPET_ENV', 'PROFILE'],
+    allowed_env_variables => $allowed_env_variables,
     defaults              => ['secure_path = /sbin:/bin:/usr/sbin:/usr/bin']
   }
 }


### PR DESCRIPTION
Whether or not this is a good idea, I want to do:
```
halyard::allowed_env_variables:
  - DEBUG
  - PUPPET_ENV
  - PROFILE
  - SSH_AUTH_SOCK
```

This let's me do that


```
❯ halyard
Repo is unclean: /opt/halyard/repo
2018-05-15 19:50:48 Jareds-MacBook-Pro.local STARTING RUN
2018-05-15 19:50:54 Jareds-MacBook-Pro.local Notice: Compiled catalog for jareds-macbook-pro.local in environment production in 0.55 seconds
2018-05-15 19:50:55 Jareds-MacBook-Pro.local Notice: /Stage[main]/Halyard/Sudoers::Allowed_command[halyard_puppet]/File[/etc/sudoers.d/halyard_puppet]/content: content changed '{md5}8fd6def48b20bcf4bd829ac382b6dc46' to '{md5}7a6862829d4223eb8e6baf25c2f6f289'
2018-05-15 19:50:57 Jareds-MacBook-Pro.local Notice: Applied catalog in 2.74 seconds
2018-05-15 19:50:57 Jareds-MacBook-Pro.local ENDING RUN
```
```
❯ sudo cat /etc/sudoers.d/halyard_puppet
# Allows halyard user to run puppet

Cmnd_Alias HALYARD_PUPPET = /opt/halyard/repo/meta/halyard,/bin/sh -c /opt/halyard/repo/meta/halyard

Defaults!HALYARD_PUPPET secure_path = /sbin:/bin:/usr/sbin:/usr/bin
Defaults!HALYARD_PUPPET env_keep+=DEBUG
Defaults!HALYARD_PUPPET env_keep+=PUPPET_ENV
Defaults!HALYARD_PUPPET env_keep+=PROFILE
Defaults!HALYARD_PUPPET env_keep+=SSH_AUTH_SOCK


jaredledvina ALL=(root) NOPASSWD: HALYARD_PUPPET
```